### PR TITLE
Add new project and new ontology wizards

### DIFF
--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/META-INF/MANIFEST.MF
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/META-INF/MANIFEST.MF
@@ -23,5 +23,6 @@ Require-Bundle: org.eclipse.ui.ide,
  io.opencaesar.oml.dsl.ide,
  io.opencaesar.oml.dsl.ui,
  io.opencaesar.oml.edit,
- io.opencaesar.oml.editor
+ io.opencaesar.oml.editor,
+ org.eclipse.xtext.ui
 Bundle-Vendor: %providerName

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/plugin.xml
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/plugin.xml
@@ -18,5 +18,51 @@
             ranking="42">
       </resolver>
    </extension>
+   <extension
+         id="nature"
+         name="OML Project"
+         point="org.eclipse.core.resources.natures">
+      <runtime>
+         <run
+               class="io.opencaesar.rosetta.oml.ui.project.OmlProject">
+         </run>
+      </runtime>
+      <builder
+            id="io.opencaesar.rosetta.oml.ui.builder">
+      </builder>
+   </extension>
+   <extension
+         id="builder"
+         name="OML Builder"
+         point="org.eclipse.core.resources.builders">
+      <builder
+            callOnEmptyDelta="true"
+            hasNature="true"
+            isConfigurable="false"
+            supportsConfigurations="false">
+         <run
+               class="io.opencaesar.rosetta.oml.ui.project.OmlProjectBuilder">
+         </run>
+      </builder>
+   </extension>
+   <extension
+         id="io.opencaesar.rosetta.oml.ui.wizards.OmlProjectWizard"
+         point="org.eclipse.ui.newWizards">
+      <wizard
+            category="org.eclipse.emf.ecore.Wizard.category.ID"
+            class="io.opencaesar.rosetta.oml.wizards.OmlProjectWizard"
+            id="io.opencaesar.rosetta.oml.ui.wizards.OmlProjectWizard"
+            name="OML Project"
+            project="true">
+      </wizard>
+      <wizard
+            category="org.eclipse.emf.ecore.Wizard.category.ID"
+            class="io.opencaesar.rosetta.oml.wizards.OmlOntologyWizard"
+            hasPages="true"
+            id="io.opencaesar.rosetta.oml.ui.wizard2"
+            name="OML Ontology"
+            project="false">
+      </wizard>
+   </extension>
 
 </plugin>

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/ui/OmlUiPlugin.java
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/ui/OmlUiPlugin.java
@@ -1,0 +1,25 @@
+package io.opencaesar.rosetta.oml.ui;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+public class OmlUiPlugin {
+
+	public static final String BUNDLE_NAME;
+	
+	public static final ILog LOG;
+	
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(OmlUiPlugin.class);
+		BUNDLE_NAME = bundle.getSymbolicName();
+		LOG = Platform.getLog(bundle);
+	}
+	
+	public static void log(IStatus status) {
+		LOG.log(status);
+	}
+	
+}

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/ui/project/OmlProject.java
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/ui/project/OmlProject.java
@@ -1,0 +1,71 @@
+package io.opencaesar.rosetta.oml.ui.project;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IProjectNature;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+
+import io.opencaesar.rosetta.oml.ui.OmlUiPlugin;
+
+/**
+ * OML Project Nature.
+ * 
+ * Adds OmlProjectBuilder to the project buildSpec.
+ */
+public class OmlProject implements IProjectNature {
+	
+	public static final String NATURE_ID = OmlUiPlugin.BUNDLE_NAME + ".nature";
+	
+	public static final String[] getRequiredNatures() {
+		return new String[] { NATURE_ID, XtextProjectHelper.NATURE_ID };
+	}
+	
+	private IProject project;
+
+	/**
+	 * Adds OmlProjectBuilder to the project buildSpec
+	 */
+	@Override
+	public void configure() throws CoreException {
+		IProjectDescription description = project.getDescription();
+		ICommand[] buildSpec = description.getBuildSpec();
+		if (Arrays.stream(buildSpec).noneMatch(OmlProjectBuilder::isBuilderFor)) {
+			ICommand[] newBuildSpec = new ICommand[buildSpec.length + 1];
+			System.arraycopy(buildSpec, 0, newBuildSpec, 0, buildSpec.length);
+			ICommand newCommand = description.newCommand();
+			newCommand.setBuilderName(OmlProjectBuilder.NAME);
+			newBuildSpec[newBuildSpec.length - 1] = newCommand;
+			description.setBuildSpec(newBuildSpec);
+			project.setDescription(description, null);
+		}
+	}
+
+	/**
+	 * Removes OmlProjectBuilder from the project buildSpec
+	 */
+	@Override
+	public void deconfigure() throws CoreException {
+		IProjectDescription description = project.getDescription();
+		ICommand[] buildSpec = description.getBuildSpec();
+		if (Arrays.stream(buildSpec).anyMatch(OmlProjectBuilder::isBuilderFor)) {
+			ICommand[] newBuildSpec = Arrays.stream(buildSpec).filter(command -> !OmlProjectBuilder.isBuilderFor(command)).toArray(ICommand[]::new);
+			description.setBuildSpec(newBuildSpec);
+			project.setDescription(description, null);
+		}
+	}
+
+	@Override
+	public IProject getProject() {
+		return project;
+	}
+
+	@Override
+	public void setProject(IProject project) {
+		this.project = project;
+	}
+
+}

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/ui/project/OmlProjectBuilder.java
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/ui/project/OmlProjectBuilder.java
@@ -1,0 +1,30 @@
+package io.opencaesar.rosetta.oml.ui.project;
+
+import java.util.Map;
+
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import io.opencaesar.rosetta.oml.ui.OmlUiPlugin;
+
+/**
+ * OML Project builder
+ * 
+ * This currently does nothing and exists as a placeholder.
+ */
+public class OmlProjectBuilder extends IncrementalProjectBuilder {
+	
+	public static final String NAME = OmlUiPlugin.BUNDLE_NAME + ".builder";
+
+	@Override
+	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
+		return null;
+	}
+
+	public static boolean isBuilderFor(ICommand command) {
+		return NAME.equals(command.getBuilderName());
+	}
+}

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/wizards/OmlOntologyWizard.java
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/wizards/OmlOntologyWizard.java
@@ -1,0 +1,334 @@
+package io.opencaesar.rosetta.oml.wizards;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.INewWizard;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.dialogs.WizardNewFileCreationPage;
+
+import io.opencaesar.oml.OmlFactory;
+import io.opencaesar.oml.OmlPackage;
+import io.opencaesar.oml.Ontology;
+import io.opencaesar.oml.SeparatorKind;
+import io.opencaesar.oml.util.OmlXMIResource;
+
+/**
+ * Wizard for creating ontology files.
+ * 
+ * Presents two pages, the first lets the user configure the ontology (type,
+ * namespace IRI, prefix, and separator) and the second lets the user select
+ * the file path and name.
+ */
+public class OmlOntologyWizard extends Wizard implements INewWizard {	
+	private OntologySetupPage ontologySetupPage;
+	private FilePage filePage;
+
+	private EClass ontologyKind;
+	private String ontologyNamespace;
+	private String ontologyPrefix;
+	private SeparatorKind ontologySeparator;
+	
+	@Override
+	public void init(IWorkbench workbench, IStructuredSelection selection) {
+		IPath folderPath = null;
+		
+		// Derive the ontology namespace from the selected folder, or use a default
+		// if not possible.
+		ontologyNamespace = "http://example.com/ontology";
+		if (selection != null) {
+			if (selection.getFirstElement() instanceof IFile) {
+				folderPath = ((IFile)selection.getFirstElement()).getParent().getFullPath();
+			} else if (selection.getFirstElement() instanceof IFolder) {
+				folderPath = ((IFolder)selection.getFirstElement()).getFullPath();
+			} else if (selection.getFirstElement() instanceof IProject) {
+				folderPath = ((IProject)selection.getFirstElement()).getFolder("src").getFullPath();
+			}
+		}
+		if (folderPath != null) {
+			if (folderPath.segmentCount() > 2 && folderPath.segment(1).equals("src")) {
+				ontologyNamespace = "http://" + Arrays.stream(folderPath.segments()).skip(2).collect(Collectors.joining("/")) + "/ontology";
+			}
+		}
+		
+		ontologySetupPage = new OntologySetupPage();
+		filePage = new FilePage(selection);
+		if (folderPath != null) {
+			filePage.setContainerFullPath(folderPath);
+		}
+		
+		setWindowTitle("Create OML Ontology");
+	}
+	
+	@Override
+	public void addPages() {
+		super.addPages();
+		addPage(ontologySetupPage);
+		addPage(filePage);
+	}
+
+	@Override
+	public boolean performFinish() {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try {
+			if (filePage.getFileName().endsWith(".oml")) {
+				// If the user saves the file with a .oml extension, generate OML text
+				OutputStreamWriter sb = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
+				if (ontologyKind == OmlPackage.Literals.DESCRIPTION) {
+					sb.append("description <");
+				} else if (ontologyKind == OmlPackage.Literals.VOCABULARY) {
+					sb.append("vocabulary <");
+				} else if (ontologyKind == OmlPackage.Literals.VOCABULARY_BUNDLE) {
+					sb.append("vocabulary bundle <");
+				}
+				sb.append(ontologyNamespace).append("> with ").append(ontologySeparator.getLiteral()).append(" as ").append(ontologyPrefix).append(" {\n");
+				sb.append("    \n");
+				sb.append("}\n");
+				sb.flush();
+			} else if (filePage.getFileName().endsWith(".omlxmi")) {
+				// If the user saves the file with a .omlxmi extension, generate OML XMI.
+				Ontology ontology = (Ontology) OmlFactory.eINSTANCE.create(ontologyKind);
+				ontology.setIri(ontologyNamespace);
+				ontology.setSeparator(ontologySeparator);
+				ontology.setPrefix(ontologyPrefix);
+				OmlXMIResource resource = new OmlXMIResource(URI.createURI(ontologyNamespace));
+				resource.getContents().add(ontology);
+				resource.doSave(baos, Collections.EMPTY_MAP);
+			} else {
+				throw new IllegalStateException("File not .oml or .omlxmi");
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		IFolder folder = ResourcesPlugin.getWorkspace().getRoot().getFolder(filePage.getContainerFullPath());
+		IFile file = folder.getFile(filePage.getFileName());
+		try {
+			file.create(new ByteArrayInputStream(baos.toByteArray()), true, new NullProgressMonitor());
+			return true;
+		} catch (CoreException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+	}
+	
+	/**
+	 * Allows the user to configure the ontology, specifying the type (vocabulary,
+	 * bundle, or description), namespace IRI, namespace separator, and namespace
+	 * prefix.
+	 * 
+	 * The prefix is derived from the last segment of the namespace IRI unless the
+	 * user explicitly changes it.
+	 */
+	private class OntologySetupPage extends WizardPage {
+		
+		private boolean ontologyPrefixChanged = false;
+		private Text ontologyPrefixInput;
+		
+		protected OntologySetupPage() {
+			super("Ontology Setup");
+			ontologySeparator = SeparatorKind.HASH;
+			setPageComplete(false);
+		}
+
+		@Override
+		public void createControl(Composite parent) {
+			Composite body = new Composite(parent, SWT.NONE);
+			body.setLayout(new GridLayout(1, true));
+
+			addOntologyKindSelector(body);
+			addNamespaceInput(body);
+			addPrefixInput(body);
+			addSeparatorInput(body);
+			
+			setControl(body);
+		}
+		
+		private void addOntologyKindSelector(Composite body) {
+			new Label(body, SWT.NONE).setText("Ontology Kind");
+			Composite row = new Composite(body, SWT.NONE);
+			row.setLayout(new GridLayout(3, false));
+			final Button vocabularyKind = new Button(row, SWT.RADIO);
+			vocabularyKind.setText("Vocabulary");
+			final Button bundleKind = new Button(row, SWT.RADIO);
+			bundleKind.setText("Bundle");
+			final Button descriptionKind = new Button(row, SWT.RADIO);
+			descriptionKind.setText("Description");
+			SelectionListener selectionListener = new SelectionListener() {
+				public void widgetDefaultSelected(SelectionEvent e) {
+					widgetSelected(e);
+				}
+				public void widgetSelected(SelectionEvent e) {
+					if (e.getSource() == vocabularyKind) {
+						ontologyKind = OmlPackage.Literals.VOCABULARY;
+					} else if (e.getSource() == bundleKind) {
+						ontologyKind = OmlPackage.Literals.VOCABULARY_BUNDLE;
+					} else if (e.getSource() == descriptionKind) {
+						ontologyKind = OmlPackage.Literals.DESCRIPTION;
+					} else {
+						ontologyKind = null;
+					}
+					onPageUpdated();
+				}
+			};
+			vocabularyKind.addSelectionListener(selectionListener);
+			bundleKind.addSelectionListener(selectionListener);
+			descriptionKind.addSelectionListener(selectionListener);
+		}
+		
+		private void addNamespaceInput(Composite body) {
+			new Label(body, SWT.NONE).setText("Namespace");
+			Text input = new Text(body, SWT.BORDER);
+			input.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
+			input.addModifyListener(event -> {
+				ontologyNamespace = input.getText();
+				onPageUpdated();
+			});
+			input.setText(ontologyNamespace);
+		}
+		
+		private void addPrefixInput(Composite body) {
+			new Label(body, SWT.NONE).setText("Prefix");
+			ontologyPrefixInput = new Text(body, SWT.BORDER);
+			ontologyPrefixInput.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
+			ontologyPrefixInput.addModifyListener(event -> {
+				ontologyPrefix = ontologyPrefixInput.getText();
+				if (ontologyPrefixInput.isFocusControl()) {
+					ontologyPrefixChanged = true;
+					onPageUpdated();
+				}
+			});
+			if (ontologyPrefix != null) {
+				ontologyPrefixInput.setText(ontologyPrefix);
+			}
+		}
+		
+		private void addSeparatorInput(Composite body) {
+			new Label(body, SWT.NONE).setText("Separator");
+			Composite row = new Composite(body, SWT.NONE);
+			row.setLayout(new GridLayout(2, false));
+			final Button hash = new Button(row, SWT.RADIO);
+			hash.setText("#");
+			hash.setSelection(true);
+			final Button slash = new Button(row, SWT.RADIO);
+			slash.setText("/");
+			SelectionListener selectionListener = new SelectionListener() {
+				public void widgetDefaultSelected(SelectionEvent e) {
+					widgetSelected(e);
+				}
+				public void widgetSelected(SelectionEvent e) {
+					if (e.getSource() == slash) {
+						ontologySeparator = SeparatorKind.SLASH;
+					} else {
+						ontologySeparator = SeparatorKind.HASH;
+					}
+					onPageUpdated();
+				}
+			};
+			hash.addSelectionListener(selectionListener);
+			slash.addSelectionListener(selectionListener);
+		}
+
+		private void onPageUpdated() {
+			try {
+				java.net.URI parsed = new java.net.URI(ontologyNamespace);
+				if (parsed.getPath() != null) {
+					String[] pathSegments = parsed.getPath().split("/");
+					String fileName = pathSegments[pathSegments.length - 1];
+					String defaultPrefix;
+					if (fileName.endsWith(".oml") || fileName.endsWith(".omlxmi")) {
+						filePage.setFileName(fileName);
+						defaultPrefix = fileName.substring(0, fileName.indexOf("."));
+					} else {
+						if (ontologyKind == OmlPackage.Literals.DESCRIPTION) {
+							filePage.setFileName(fileName + ".omlxmi");
+						} else {
+							filePage.setFileName(fileName + ".oml");
+						}
+						defaultPrefix = fileName;
+					}
+					if (!ontologyPrefixChanged) {
+						ontologyPrefix = defaultPrefix;
+						if (ontologyPrefixInput != null) {
+							ontologyPrefixInput.setText(ontologyPrefix);
+						}
+					}
+				}
+			} catch (URISyntaxException e) {
+				// Ensure the IRI is valid
+				setPageComplete(false);
+				return;
+			}
+			if (ontologyKind == null) {
+				setPageComplete(false);
+				return;
+			}
+			setPageComplete(true);
+		}
+	}
+
+	/**
+	 * File Creation Page
+	 * 
+	 * Lets the user select a folder (by default the folder selected by the user when launching
+	 * the wizard) and filename (by default the last segment of the namespace IRI, with a .oml
+	 * extension for vocabularies and bundles or a .omlxmi extension for descriptions.)
+	 */
+	private class FilePage extends WizardNewFileCreationPage {
+
+		protected FilePage(IStructuredSelection selection) {
+			super("FilePage", selection);
+		}
+
+		@Override
+		public boolean validatePage() {
+			if (super.validatePage()) {
+				String fileName = this.getFileName();
+				if (fileName == null) {
+					return false;
+				}
+				if (!getFileName().endsWith(".oml") && !getFileName().endsWith(".omlxmi")) {
+					return false;
+				}
+				if (this.getContainerFullPath() == null) {
+					return false;
+				}
+				IPath containerPath = this.getContainerFullPath();
+				IContainer container = ResourcesPlugin.getWorkspace().getRoot().getFolder(containerPath);
+				if (container == null) {
+					return false;
+				}
+			}
+			return true;
+		}
+		
+	}
+}

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/wizards/OmlProjectWizard.java
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/wizards/OmlProjectWizard.java
@@ -1,0 +1,93 @@
+package io.opencaesar.rosetta.oml.wizards;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
+import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
+
+import io.opencaesar.rosetta.oml.ui.OmlUiPlugin;
+import io.opencaesar.rosetta.oml.ui.project.OmlProject;
+import io.opencaesar.rosetta.oml.ui.project.OmlProjectBuilder;
+
+/**
+ * Wizard for creating OML projects. Creates a "src" folder and configures
+ * the project to have OML and Xtext natures.
+ */
+public class OmlProjectWizard extends BasicNewResourceWizard {
+		
+	private WizardNewProjectCreationPage mainPage = new WizardNewProjectCreationPage("Create OML Project");
+	private IProject newProject;
+	
+	@Override
+	public void init(IWorkbench workbench, IStructuredSelection selection) {
+		super.init(workbench, selection);
+		setWindowTitle("Create OML Project");
+	}
+	
+	@Override
+	public void addPages() {
+		super.addPages();
+		addPage(mainPage);
+	}
+
+	@Override
+	public boolean performFinish() {
+		String projectName = mainPage.getProjectName();
+		URI projectLocation = mainPage.getLocationURI();
+		if (projectLocation == null) {
+			return false;
+		}
+		if (newProject == null) {
+			try {
+				getContainer().run(true, false, monitor -> createProject(monitor, projectName, projectLocation));
+				getWorkbench().getWorkingSetManager().addToWorkingSets(newProject, mainPage.getSelectedWorkingSets());
+				selectAndReveal(newProject);
+				return true;
+			} catch (InvocationTargetException | InterruptedException e) {
+				OmlUiPlugin.log(new Status(IStatus.ERROR, OmlUiPlugin.BUNDLE_NAME, IStatus.ERROR, e.getMessage(), e));
+			}
+		}
+		return false;
+	}
+	
+	private void createProject(IProgressMonitor monitor, String projectName, URI projectLocation) {
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 30);
+		IProjectDescription description = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+		description.setLocationURI(projectLocation);
+		description.setNatureIds(OmlProject.getRequiredNatures());
+		ICommand buildCommand = description.newCommand();
+		buildCommand.setBuilderName(OmlProjectBuilder.NAME);
+		description.setBuildSpec(new ICommand[] { buildCommand });
+		newProject = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		try {
+			newProject.create(description, subMonitor.split(10));
+			newProject.open(subMonitor.split(10));
+			IFolder srcFolder = newProject.getFolder("src");
+			srcFolder.create(true, true, subMonitor.split(10));
+		} catch (Exception e) {
+			if (newProject != null && newProject.exists()) {
+				try {
+					newProject.delete(true, new NullProgressMonitor());
+				} catch (CoreException ignored) {
+					
+				}
+			}
+			throw new RuntimeException(e.getMessage(), e);
+		}
+	}
+	
+}

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/wizards/OmlProjectWizard.java
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.oml.ui/src/io/opencaesar/rosetta/oml/wizards/OmlProjectWizard.java
@@ -15,6 +15,8 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
 import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
@@ -27,15 +29,16 @@ import io.opencaesar.rosetta.oml.ui.project.OmlProjectBuilder;
  * Wizard for creating OML projects. Creates a "src" folder and configures
  * the project to have OML and Xtext natures.
  */
-public class OmlProjectWizard extends BasicNewResourceWizard {
+public class OmlProjectWizard extends Wizard implements INewWizard {
 		
+	private IWorkbench workbench;
 	private WizardNewProjectCreationPage mainPage = new WizardNewProjectCreationPage("Create OML Project");
 	private IProject newProject;
 	
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
-		super.init(workbench, selection);
 		setWindowTitle("Create OML Project");
+		this.workbench = workbench;
 	}
 	
 	@Override
@@ -54,8 +57,8 @@ public class OmlProjectWizard extends BasicNewResourceWizard {
 		if (newProject == null) {
 			try {
 				getContainer().run(true, false, monitor -> createProject(monitor, projectName, projectLocation));
-				getWorkbench().getWorkingSetManager().addToWorkingSets(newProject, mainPage.getSelectedWorkingSets());
-				selectAndReveal(newProject);
+				workbench.getWorkingSetManager().addToWorkingSets(newProject, mainPage.getSelectedWorkingSets());
+				BasicNewResourceWizard.selectAndReveal(newProject, workbench.getActiveWorkbenchWindow());
 				return true;
 			} catch (InvocationTargetException | InterruptedException e) {
 				OmlUiPlugin.log(new Status(IStatus.ERROR, OmlUiPlugin.BUNDLE_NAME, IStatus.ERROR, e.getMessage(), e));

--- a/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.target/io.opencaesar.rosetta.target.target
+++ b/io.opencaesar.rosetta.parent/io.opencaesar.rosetta.target/io.opencaesar.rosetta.target.target
@@ -22,7 +22,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="io.opencaesar.oml.ui.feature.feature.group" version="0.0.0"/>
 			<unit id="io.opencaesar.oml.dsl.ui.feature.feature.group" version="0.0.0"/>
-			<repository location="https://dl.bintray.com/opencaesar/p2/oml/releases/0.7.0/"/>
+			<repository location="https://dl.bintray.com/opencaesar/p2/oml/releases/0.7.1/"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
The new project wizard configures the project to have OML and Xtext natures and creates a `src` directory.

The new ontology wizard creates a vocabulary, bundle, or description ontology, and allows the user to specify a namespace IRI, separator, and prefix.

By default, description ontologies are saved as OML XMI and vocabulary and bundle ontologies are saved as OML text.

### New Project Wizard

![Screen Shot 2020-06-09 at 8 21 19 AM](https://user-images.githubusercontent.com/769485/84166773-37d0ca80-aa2a-11ea-98e8-a8f05ee541bc.png)

### New Ontology Wizard

![Screen Shot 2020-06-15 at 6 06 56 PM](https://user-images.githubusercontent.com/769485/84720495-088ef180-af33-11ea-93c8-03df515aa9d5.png)

![Screen Shot 2020-06-09 at 8 24 22 AM](https://user-images.githubusercontent.com/769485/84167107-ac0b6e00-aa2a-11ea-95f3-730a90c5c080.png)
