### PR TITLE
Add Sirius context menu extensions to cross-table editors

### DIFF
--- a/io.opencaesar.rosetta.sirius/plugin.xml
+++ b/io.opencaesar.rosetta.sirius/plugin.xml
@@ -49,6 +49,28 @@
                tooltip="Validate the selected element">
          </command>
       </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="popup:org.eclipse.sirius.table.ui.CrossTableEditorID?before=hideGroup">
+         <command
+               commandId="io.opencaesar.rosetta.sirius.handlers.CollapseLineHandler"
+               label="Collapse"
+               style="push"
+               tooltip="Collapse the selected element">
+         </command>
+         <command
+               commandId="io.opencaesar.rosetta.sirius.handlers.ExpandLineHandler"
+               label="Expand"
+               style="push"
+               tooltip="Expand the selected element">
+         </command>
+         <command
+               commandId="io.opencaesar.rosetta.sirius.handlers.ValidateLineHandler"
+               label="Validate"
+               style="push"
+               tooltip="Validate the selected element">
+         </command>
+      </menuContribution>
    </extension>
    <extension
          point="org.eclipse.ui.editors">


### PR DESCRIPTION
Our Sirius table context menu items (Expand, Collapse, Validate) were only configured to appear in edition tables; this adds them to cross tables as well.